### PR TITLE
if git-authors file has no keys, return default keys

### DIFF
--- a/lib/vinz/clortho/ssh_key_path_manager.rb
+++ b/lib/vinz/clortho/ssh_key_path_manager.rb
@@ -16,15 +16,19 @@ module Vinz
     class SSHKeyPathManager
       attr_reader :key_paths
 
-      DEFAULT_KEY_PATH = '/Volumes/*/.ssh/id_rsa'
+      DEFAULT_KEYS = lambda { Dir['/Volumes/*/.ssh/id_rsa'].map { |path| KeyPathEntry.new(path) } }
 
       def initialize
         @key_paths = if git_authors_file.nil?
-          Dir[DEFAULT_KEY_PATH].map { |path| KeyPathEntry.new(path) }
+          DEFAULT_KEYS.call
         else
           git_authors = YAML::load_file(git_authors_file)
-          git_authors['sshkey_paths'].map do |initials, path|
-            KeyPathEntry.new(path, initials)
+          if git_authors.has_key? 'sshkey_paths'
+            git_authors['sshkey_paths'].map do |initials, path|
+              KeyPathEntry.new(path, initials)
+            end
+          else
+            DEFAULT_KEYS.call
           end
         end
       end

--- a/test/vinz/clortho/ssh_key_path_manager_test.rb
+++ b/test/vinz/clortho/ssh_key_path_manager_test.rb
@@ -73,5 +73,19 @@ module Vinz::Clortho
         assert_includes keys, path
       end
     end
+
+    def test_key_paths_returns_all_available_paths_if_no_sshkey_paths
+      committers = @initial_committers.reject { |k, v| k == 'sshkey_paths' }
+      current_dir_git_authors = File.join(Dir.pwd, '.git-authors')
+      File.expects(:exist?).with(current_dir_git_authors).returns true
+      YAML.expects(:load_file).with(current_dir_git_authors).returns committers
+
+      keys = ["/Volumes/hpotter/.ssh/id_rsa", "/Volumes/hgranger/.ssh/id_rsa"]
+      Dir.expects(:[]).with("/Volumes/*/.ssh/id_rsa").returns(keys)
+      mgr = SSHKeyPathManager.new
+      mgr.key_paths.map(&:path).each do |path|
+        assert_includes keys, path
+      end
+    end
   end
 end


### PR DESCRIPTION
@ehrenmurdick @navyasric this fixes an issue I was running into where we had a `.git-authors` file, but it didn't have an `sshkey_paths` entry. I think this should just act as if there wasn't a git-authors file in the first place.

I did this as a PR as I'm doing this solo, feel free to add feedback or make changes in the branch and then we can merge it in (or if you like it, we can just accept it as is).
